### PR TITLE
address netlify warning

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,7 @@
 
 [functions]
   node_bundler = "esbuild"
+  external_node_modules = ["@remix-run/react"]
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
-----------------
Warning verbatim:
-----------------

The following Node.js modules use dynamic expressions to include files:
    - @remix-run/react

Because files included with dynamic expressions aren't bundled with your
serverless functions by default, this may result in an error when invoking
a function. To resolve this error, you can mark these Node.js modules as
external in the [functions] section of your `netlify.toml` configuration
file:

    [functions]
        external_node_modules = ["@remix-run/react"]

Visit https://ntl.fyi/dynamic-imports for more information.